### PR TITLE
After hook arity warning

### DIFF
--- a/lib/roda/plugins/enhanced_logger.rb
+++ b/lib/roda/plugins/enhanced_logger.rb
@@ -70,7 +70,8 @@ class Roda
           @_enhanced_logger_instance = Roda::EnhancedLogger::Instance.new(logger, env, object_id, root, options[:filter])
         end
 
-        app.after do |status, _|
+        app.after do |res|
+          status, _ = res
           @_enhanced_logger_instance.add(
             status,
             request,


### PR DESCRIPTION
In Roda version 3.72, the `define_roda_method` that is called in after hook, in the hooks plugin, expects a block with the arity of one. 

```ruby
        # roda/plugins/hooks.rb
        # Add an after hook.
        def after(&block)
          opts[:after_hooks] << define_roda_method("after_hook", 1, &block)
          if opts[:after_hooks].length == 1
            class_eval("alias _roda_after_80__hooks #{opts[:after_hooks].first}", __FILE__, __LINE__)
          else
            class_eval("def _roda_after_80__hooks(res) #{opts[:after_hooks].map{|m| "#{m}(res)"}.join(';')} end", __FILE__, __LINE__)
          end
          private :_roda_after_80__hooks
          def_roda_after
          nil
        end

        # lib/roda.rb
        # If the :check_arity app option is not set to false, Roda will check that
        # the arity of the block matches the expected arity, and compensate for
        # cases where it does not.  If it is set to :warn, Roda will warn in the
        # cases where the arity does not match what is expected.
        #
        # If the expected arity is :any, Roda must perform a dynamic arity check
        # when the method is called, which can hurt performance even in the case
        # where the arity matches.  The :check_dynamic_arity app option can be
        # set to false to turn off the dynamic arity checks.  The
        # :check_dynamic_arity app option can be to :warn to warn if Roda needs
        # to adjust arity dynamically
        #...
        
         def define_roda_method(meth, expected_arity, &block)
           ...
            if keyword == :required && (expected_arity == 0 || expected_arity == 1)
              raise RodaError, "cannot use block with required keyword arguments when calling define_roda_method with expected arity #{expected_arity}"
            end
            ...
         end
```

Splitting the response array in the block parameters triggers the warning and potentially incurs a dynamic arity check with a performance penalty. I just moved the definition down, and it acts as expected.